### PR TITLE
Badge condition rework to expand trigger and check options

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -518,7 +518,6 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 		value = true
 	}
 	c.switchCache[switchId] = value
-
 	if switchId == 1430 && serverConfig.GameName == "2kki" { // time trial mode
 		if value {
 			c.send <- buildMsg("sv", "88", "0") // time elapsed

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -588,7 +588,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 						}
 					}
 				} else if len(condition.SwitchIds) != 0 {
-					if valid, s := condition.checkSwitch(switchId, value); valid {
+					if valid, _ := condition.checkSwitch(switchId, value); valid {
 						// check switch cache for existing switch states
                         var condSwitchesPass bool = true;
                         for _, otherCondSwId := range condition.SwitchIds {
@@ -596,7 +596,8 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
                                 // this is the same switch just received, so it must be correct
                                 continue
                             }
-                            if othCondSwVal, ok := c.switchCache[otherCondSwId]; !ok {
+                            othCondSwVal, ok = c.switchCache[otherCondSwId]
+                            if !ok {
                                 // state of switch unknown; request from client and break
                                 c.send <- buildMsg("ss", otherCondSwId, "0")
                                 condSwitchesPass = false;
@@ -743,7 +744,7 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 						}
 					}
 				} else if len(condition.VarIds) != 0 {
-					if valid, v := condition.checkVar(varId, value); valid {
+					if valid, _ := condition.checkVar(varId, value); valid {
                         // check var cache for existing var vals
                         var condVarsPass bool = true;
                         for _, otherCondVarId := range condition.VarIds {
@@ -751,7 +752,8 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
                                 // this is the same var just received, so it must be correct
                                 continue
                             }
-                            if othCondVarVal, ok := c.varCache[otherCondVarId]; !ok {
+                            othCondVarVal, ok = c.varCache[otherCondVarId]
+                            if !ok {
                                 // state of var unknown; request from client and break
                                 c.send <- buildMsg("sv", otherCondVarId, "0")
                                 condVarsPass = false;

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -518,7 +518,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 		value = true
 	}
 	c.switchCache[switchId] = value
-    
+
 	if switchId == 1430 && serverConfig.GameName == "2kki" { // time trial mode
 		if value {
 			c.send <- buildMsg("sv", "88", "0") // time elapsed
@@ -590,30 +590,30 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 				} else if len(condition.SwitchIds) != 0 {
 					if valid, _ := condition.checkSwitch(switchId, value); valid {
 						// check switch cache for existing switch states
-                        var condSwitchesPass bool = true;
-                        for _, otherCondSwId := range condition.SwitchIds {
-                            if otherCondSwId == switchId {
-                                // this is the same switch just received, so it must be correct
-                                continue
-                            }
-                            othCondSwVal, ok := c.switchCache[otherCondSwId]
-                            if !ok {
-                                // state of switch unknown; request from client and break
-                                c.send <- buildMsg("ss", otherCondSwId, "0")
-                                condSwitchesPass = false;
-                                break
-                            }
-                            if valid, _ := condition.checkSwitch(otherCondSwId, othCondSwVal); !valid {
-                                // switch state isn't correct; break
-                                // if switch is set nearly at same time, it will have its own message handled
-                                condSwitchesPass = false;
-                                break
-                            }
-                        }
-                        
-                        // only continue if all switch states are correct
-                        if condSwitchesPass {
-                            if condition.VarTrigger || (condition.VarId == 0 && len(condition.VarIds) == 0) {
+						var condSwitchesPass bool = true;
+						for _, otherCondSwId := range condition.SwitchIds {
+							if otherCondSwId == switchId {
+								// this is the same switch just received, so it must be correct
+								continue
+							}
+							othCondSwVal, ok := c.switchCache[otherCondSwId]
+							if !ok {
+								// state of switch unknown; request from client and break
+								c.send <- buildMsg("ss", otherCondSwId, "0")
+								condSwitchesPass = false;
+								break
+							}
+							if valid, _ := condition.checkSwitch(otherCondSwId, othCondSwVal); !valid {
+								// switch state isn't correct; break
+								// if switch is set nearly at same time, it will have its own message handled
+								condSwitchesPass = false;
+								break
+							}
+						}
+
+						// only continue if all switch states are correct
+						if condSwitchesPass {
+							if condition.VarTrigger || (condition.VarId == 0 && len(condition.VarIds) == 0) {
 								if !condition.TimeTrial {
 									if c.checkConditionCoords(condition) {
 										success, err := tryWritePlayerTag(c.sClient.uuid, condition.ConditionId)
@@ -634,7 +634,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 								}
 								c.send <- buildMsg("sv", varId, "0")
 							}
-                        }
+						}
 					}
 				}
 			}
@@ -745,31 +745,31 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 					}
 				} else if len(condition.VarIds) != 0 {
 					if valid, _ := condition.checkVar(varId, value); valid {
-                        // check var cache for existing var vals
-                        var condVarsPass bool = true;
-                        for _, otherCondVarId := range condition.VarIds {
-                            if otherCondVarId == varId {
-                                // this is the same var just received, so it must be correct
-                                continue
-                            }
-                            othCondVarVal, ok := c.varCache[otherCondVarId]
-                            if !ok {
-                                // state of var unknown; request from client and break
-                                c.send <- buildMsg("sv", otherCondVarId, "0")
-                                condVarsPass = false;
-                                break
-                            }
-                            if valid, _ := condition.checkVar(otherCondVarId, othCondVarVal); !valid {
-                                // var val isn't correct; break
-                                // if var is set nearly at same time, it will have its own message handled
-                                condVarsPass = false;
-                                break
-                            }
-                        }
-                        
-                        // only continue if all var vals are correct
-                        if condVarsPass {
-                            if !condition.VarTrigger || (condition.SwitchId == 0 && len(condition.SwitchIds) == 0) {
+						// check var cache for existing var vals
+						var condVarsPass bool = true;
+						for _, otherCondVarId := range condition.VarIds {
+							if otherCondVarId == varId {
+								// this is the same var just received, so it must be correct
+								continue
+							}
+							othCondVarVal, ok := c.varCache[otherCondVarId]
+							if !ok {
+								// state of var unknown; request from client and break
+								c.send <- buildMsg("sv", otherCondVarId, "0")
+								condVarsPass = false;
+								break
+							}
+							if valid, _ := condition.checkVar(otherCondVarId, othCondVarVal); !valid {
+								// var val isn't correct; break
+								// if var is set nearly at same time, it will have its own message handled
+								condVarsPass = false;
+								break
+							}
+						}
+
+						// only continue if all var vals are correct
+						if condVarsPass {
+							if !condition.VarTrigger || (condition.SwitchId == 0 && len(condition.SwitchIds) == 0) {
 								if !condition.TimeTrial {
 									if c.checkConditionCoords(condition) {
 										success, err := tryWritePlayerTag(c.sClient.uuid, condition.ConditionId)
@@ -790,7 +790,7 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 								}
 								c.send <- buildMsg("ss", switchId, "0")
 							}
-                        }
+						}
 					}
 				}
 			}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -589,7 +589,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 				} else if len(condition.SwitchIds) != 0 {
 					if valid, _ := condition.checkSwitch(switchId, value); valid {
 						// check switch cache for existing switch states
-						var condSwitchesPass bool = true;
+						condSwitchesPass := true
 						for _, otherCondSwId := range condition.SwitchIds {
 							if otherCondSwId == switchId {
 								// this is the same switch just received, so it must be correct
@@ -599,13 +599,13 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 							if !ok {
 								// state of switch unknown; request from client and break
 								c.send <- buildMsg("ss", otherCondSwId, "0")
-								condSwitchesPass = false;
+								condSwitchesPass = false
 								break
 							}
 							if valid, _ := condition.checkSwitch(otherCondSwId, othCondSwVal); !valid {
 								// switch state isn't correct; break
 								// if switch is set nearly at same time, it will have its own message handled
-								condSwitchesPass = false;
+								condSwitchesPass = false
 								break
 							}
 						}
@@ -745,7 +745,7 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 				} else if len(condition.VarIds) != 0 {
 					if valid, _ := condition.checkVar(varId, value); valid {
 						// check var cache for existing var vals
-						var condVarsPass bool = true;
+						condVarsPass := true
 						for _, otherCondVarId := range condition.VarIds {
 							if otherCondVarId == varId {
 								// this is the same var just received, so it must be correct
@@ -755,13 +755,13 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 							if !ok {
 								// state of var unknown; request from client and break
 								c.send <- buildMsg("sv", otherCondVarId, "0")
-								condVarsPass = false;
+								condVarsPass = false
 								break
 							}
 							if valid, _ := condition.checkVar(otherCondVarId, othCondVarVal); !valid {
 								// var val isn't correct; break
 								// if var is set nearly at same time, it will have its own message handled
-								condVarsPass = false;
+								condVarsPass = false
 								break
 							}
 						}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -596,7 +596,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
                                 // this is the same switch just received, so it must be correct
                                 continue
                             }
-                            othCondSwVal, ok = c.switchCache[otherCondSwId]
+                            othCondSwVal, ok := c.switchCache[otherCondSwId]
                             if !ok {
                                 // state of switch unknown; request from client and break
                                 c.send <- buildMsg("ss", otherCondSwId, "0")
@@ -752,7 +752,7 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
                                 // this is the same var just received, so it must be correct
                                 continue
                             }
-                            othCondVarVal, ok = c.varCache[otherCondVarId]
+                            othCondVarVal, ok := c.varCache[otherCondVarId]
                             if !ok {
                                 // state of var unknown; request from client and break
                                 c.send <- buildMsg("sv", otherCondVarId, "0")

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -518,6 +518,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 		value = true
 	}
 	c.switchCache[switchId] = value
+    
 	if switchId == 1430 && serverConfig.GameName == "2kki" { // time trial mode
 		if value {
 			c.send <- buildMsg("sv", "88", "0") // time elapsed
@@ -588,8 +589,30 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 					}
 				} else if len(condition.SwitchIds) != 0 {
 					if valid, s := condition.checkSwitch(switchId, value); valid {
-						if s == len(condition.SwitchIds)-1 {
-							if condition.VarTrigger || (condition.VarId == 0 && len(condition.VarIds) == 0) {
+						// check switch cache for existing switch states
+                        var condSwitchesPass bool = true;
+                        for _, otherCondSwId := range condition.SwitchIds {
+                            if otherCondSwId == switchId {
+                                // this is the same switch just received, so it must be correct
+                                continue
+                            }
+                            if othCondSwVal, ok := c.switchCache[otherCondSwId]; !ok {
+                                // state of switch unknown; request from client and break
+                                c.send <- buildMsg("ss", otherCondSwId, "0")
+                                condSwitchesPass = false;
+                                break
+                            }
+                            if valid, _ := condition.checkSwitch(otherCondSwId, othCondSwVal); !valid {
+                                // switch state isn't correct; break
+                                // if switch is set nearly at same time, it will have its own message handled
+                                condSwitchesPass = false;
+                                break
+                            }
+                        }
+                        
+                        // only continue if all switch states are correct
+                        if condSwitchesPass {
+                            if condition.VarTrigger || (condition.VarId == 0 && len(condition.VarIds) == 0) {
 								if !condition.TimeTrial {
 									if c.checkConditionCoords(condition) {
 										success, err := tryWritePlayerTag(c.sClient.uuid, condition.ConditionId)
@@ -610,9 +633,7 @@ func (c *RoomClient) handleSs(msg []string) (err error) {
 								}
 								c.send <- buildMsg("sv", varId, "0")
 							}
-						} else {
-							c.send <- buildMsg("ss", condition.SwitchIds[s+1], "0")
-						}
+                        }
 					}
 				}
 			}
@@ -723,8 +744,30 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 					}
 				} else if len(condition.VarIds) != 0 {
 					if valid, v := condition.checkVar(varId, value); valid {
-						if v == len(condition.VarIds)-1 {
-							if !condition.VarTrigger || (condition.SwitchId == 0 && len(condition.SwitchIds) == 0) {
+                        // check var cache for existing var vals
+                        var condVarsPass bool = true;
+                        for _, otherCondVarId := range condition.VarIds {
+                            if otherCondVarId == varId {
+                                // this is the same var just received, so it must be correct
+                                continue
+                            }
+                            if othCondVarVal, ok := c.varCache[otherCondVarId]; !ok {
+                                // state of var unknown; request from client and break
+                                c.send <- buildMsg("sv", otherCondVarId, "0")
+                                condVarsPass = false;
+                                break
+                            }
+                            if valid, _ := condition.checkVar(otherCondVarId, othCondVarVal); !valid {
+                                // var val isn't correct; break
+                                // if var is set nearly at same time, it will have its own message handled
+                                condVarsPass = false;
+                                break
+                            }
+                        }
+                        
+                        // only continue if all var vals are correct
+                        if condVarsPass {
+                            if !condition.VarTrigger || (condition.SwitchId == 0 && len(condition.SwitchIds) == 0) {
 								if !condition.TimeTrial {
 									if c.checkConditionCoords(condition) {
 										success, err := tryWritePlayerTag(c.sClient.uuid, condition.ConditionId)
@@ -745,9 +788,7 @@ func (c *RoomClient) handleSv(msg []string) (err error) {
 								}
 								c.send <- buildMsg("ss", switchId, "0")
 							}
-						} else {
-							c.send <- buildMsg("sv", condition.VarIds[v+1], "0")
-						}
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
Uses the switch and variable caches to loop over all of the conditions for a badge without network overhead, only requesting syncs as needed.