### PR TITLE
Fixed a bug that caused time trial buildMsg to be duplicated

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -643,10 +643,14 @@ func (c *RoomClient) handleSv(msg []string) error {
 	conditions := append(globalConditions, c.room.conditions...)
 
 	if varId == 88 && config.gameName == "2kki" {
+		notifiedMaps := make(map[int]bool)
 		for _, condition := range conditions {
 			if condition.TimeTrial && value < 3600 {
 				if c.checkConditionCoords(condition) {
-					c.session.outbox <- buildMsg("ttr", c.room.id, value)
+					if !notifiedMaps[condition.Map] {
+						c.session.outbox <- buildMsg("ttr", condition.Map, value)
+						notifiedMaps[condition.Map] = true
+					}
 					success, err := tryWritePlayerTimeTrial(c.session.uuid, c.room.id, value)
 					if err != nil {
 						return err

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -648,7 +648,7 @@ func (c *RoomClient) handleSv(msg []string) error {
 			if condition.TimeTrial && value < 3600 {
 				if c.checkConditionCoords(condition) {
 					if !notifiedMaps[condition.Map] {
-						c.session.outbox <- buildMsg("ttr", condition.Map, value)
+						c.session.outbox <- buildMsg("ttr", c.room.id, value)
 						notifiedMaps[condition.Map] = true
 					}
 					success, err := tryWritePlayerTimeTrial(c.session.uuid, c.room.id, value)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -646,7 +646,7 @@ func (c *RoomClient) handleSv(msg []string) error {
 		for _, condition := range conditions {
 			if condition.TimeTrial && value < 3600 {
 				if c.checkConditionCoords(condition) {
-					c.outbox <- buildMsg("ttr", c.room.id, value)
+					c.session.outbox <- buildMsg("ttr", c.room.id, value)
 					success, err := tryWritePlayerTimeTrial(c.session.uuid, c.room.id, value)
 					if err != nil {
 						return err

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -646,6 +646,7 @@ func (c *RoomClient) handleSv(msg []string) error {
 		for _, condition := range conditions {
 			if condition.TimeTrial && value < 3600 {
 				if c.checkConditionCoords(condition) {
+					c.outbox <- buildMsg("ttr", c.room.id, value)
 					success, err := tryWritePlayerTimeTrial(c.session.uuid, c.room.id, value)
 					if err != nil {
 						return err


### PR DESCRIPTION
fix ensures buildMsg are sent only once per time trial category, regardless of the player's current condition.