### PR TITLE
Fix player direction getting reversed after moving

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -69,13 +69,13 @@ func (c *RoomClient) handleM(msg []string) error {
 
 	if msg[0] == "m" {
 		switch {
-		case c.y < y:
+		case y < c.y:
 			c.facing = 0 // up
-		case c.x > x:
+		case x > c.x:
 			c.facing = 1 // right
-		case c.y > y:
+		case y > c.y:
 			c.facing = 2 // down
-		case c.x < x:
+		case x < c.x:
 			c.facing = 3 // left
 		}
 	}


### PR DESCRIPTION
This was usually noticeable only after reconnecting or reentering the room because clients calculate other players' post-move facing direction clientside; another potential reason it may have been overlooked is that moving south (a common facing direction used while idling) set the facing to 0 (north), which due to [a client oversight](/ynoproject/ynoengine/pull/67) was displayed as the default liblcf direction, [which happened to also be south][0].

[0]: https://github.com/EasyRPG/liblcf/blob/92c4450a1bc1acb58bd02bbb99b57e5036919cdf/src/generated/lcf/rpg/savemapeventbase.h#L37