### PR TITLE
Ensure clients can't get the same ID if they connect at the same time

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -344,6 +344,31 @@ func (m *SClientMap) Store(uuid string, client *SessionClient) {
 	m.mutex.Unlock()
 }
 
+func (m *SClientMap) nextFreeId() (id int) {
+	for i := 0; i < 0xFFFF; i++ {
+		var used bool
+		for _, client := range m.clients {
+			if client.id == i {
+				used = true
+			}
+		}
+
+		if !used {
+			id = i
+			break
+		}
+	}
+	return id
+}
+
+func (m *SClientMap) StoreAndSetId(uuid string, client *SessionClient) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	client.id = m.nextFreeId()
+	m.clients[uuid] = client
+}
+
 func (m *SClientMap) Load(uuid string) (*SessionClient, bool) {
 	m.mutex.RLock()
 

--- a/server/session.go
+++ b/server/session.go
@@ -137,26 +137,14 @@ func joinSessionWs(conn *websocket.Conn, ip string, token string) {
 		c.badge = "null"
 	}
 
-	for i := 0; i < 0xFFFF; i++ {
-		var used bool
-		for _, client := range clients.Get() {
-			if client.id == i {
-				used = true
-			}
-		}
-
-		if !used {
-			c.id = i
-			break
-		}
-	}
-
 	c.sprite, c.spriteIndex, c.system = getPlayerGameData(c.uuid)
 
 	go c.msgWriter()
 
-	// register client to the clients list
-	clients.Store(c.uuid, c)
+	// register client to the clients list;
+	// assign session-specific ID in the same critical section to ensure
+	// only one client gets the given ID
+	clients.StoreAndSetId(c.uuid, c)
 
 	go c.msgReader()
 


### PR DESCRIPTION
Having multiple players with the same ID can result in [interesting behavior](https://github.com/user-attachments/assets/059aa729-b56d-4e40-9f91-dbe5a51f5b98) (the maiko was an unnamed logged out player).

I could (not very reliably) reproduce the bug by manually restarting the server a few times while having a few clients open on the same machine but it gets significantly easier to trigger if you insert a sleep here:
```diff
		if !used {
+			time.Sleep(time.Second)
			c.id = i
			break
		}
```
