### PR TITLE
Fix wrong error check when loading blocked players

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -153,7 +153,7 @@ func joinSessionWs(conn *websocket.Conn, ip string, token string) {
 		writeErrLog(c.uuid, "sess", err.Error())
 	}
 
-	if blockedPlayers, err := getBlockedPlayerData(c.uuid); err != nil {
+	if blockedPlayers, err := getBlockedPlayerData(c.uuid); err == nil {
 		for _, player := range blockedPlayers {
 			c.blockedUsers[player.Uuid] = true
 		}


### PR DESCRIPTION
Changed the condition from `err != nil` to `err == nil` to ensure that blockedPlayers are only handled when data is successfully retrieved.

if it seems to be work, please merge or push to testserver, thank you.