### PR TITLE
Fix populate blockedUsers before registering SessionClient

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -139,6 +139,12 @@ func joinSessionWs(conn *websocket.Conn, ip string, token string) {
 
 	c.sprite, c.spriteIndex, c.system = getPlayerGameData(c.uuid)
 
+	if blockedPlayers, err := getBlockedPlayerData(c.uuid); err == nil {
+		for _, player := range blockedPlayers {
+			c.blockedUsers[player.Uuid] = true
+		}
+	}
+
 	go c.msgWriter()
 
 	// register client to the clients list;
@@ -151,12 +157,6 @@ func joinSessionWs(conn *websocket.Conn, ip string, token string) {
 	err := c.addOrUpdatePlayerGameData()
 	if err != nil {
 		writeErrLog(c.uuid, "sess", err.Error())
-	}
-
-	if blockedPlayers, err := getBlockedPlayerData(c.uuid); err == nil {
-		for _, player := range blockedPlayers {
-			c.blockedUsers[player.Uuid] = true
-		}
 	}
 
 	writeLog(c.uuid, "sess", "connect", 200)


### PR DESCRIPTION
Reloading the page could momentarily expose blocked players, because session was published before its blockedUsers map was filled. The fix probably loads the block list first, eliminating that race condition.

if it seems to be work, please push to playtest, thank you everytime.