### PR TITLE
Don't set facing on initial position update

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -67,7 +67,9 @@ func (c *RoomClient) handleM(msg []string) error {
 		return errconv
 	}
 
-	if msg[0] == "m" {
+	// c.x and c.y get set at the same time
+	// only one needs to be checked
+	if msg[0] == "m" && c.x != -1 {
 		switch {
 		case y < c.y:
 			c.facing = 0 // up


### PR DESCRIPTION
Prevents clients from having their facing set to east in case they don't send an `f` packet after connecting. The cause was the `x > c.x` condition always being hit (any valid X coordinate > -1). Prior to 651597c74 the extra condition wasn't strictly necessary because north-facing (default, no `f` sent) clients would've hit `c.y < y` (-1 < any valid Y coordinate) and have their facing set to north again.

---

Reproduction steps:
1. connect with player 1
2. connect with player 2
3. ensure they're both in the same room
4. make player 1 face north
5. reconnect with player 1 (to reset position to (-1, -1))
6. reconnect with player 2 (to get server facing instead of client facing)

Facing of player 2 as seen by player 1 after doing all of the above:
Current `master`:  east
This patch: south (due to the bug described in ynoproject/ynoengine#67; north on the server)