### PR TITLE
More granular private mode (#62)

### DIFF
--- a/server/friends.go
+++ b/server/friends.go
@@ -119,7 +119,7 @@ func getPlayerFriendData(uuid string) (playerFriends []*PlayerFriend, err error)
 				playerFriend.Badge = client.badge
 				playerFriend.Medals = client.medals
 
-				if client.roomC != nil && !(client.hideLocation && client.singleplayer) {
+				if client.roomC != nil && !(client.hideLocation && client.isSingleplayer()) {
 					playerFriend.MapId = client.roomC.mapId
 					playerFriend.PrevMapId = client.roomC.prevMapId
 					playerFriend.PrevLocations = client.roomC.prevLocations

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1334,8 +1334,13 @@ func (c *SessionClient) handlePr(msg []string) error {
 		return errors.New("segment count mismatch")
 	}
 
-	c.singleplayer = msg[1] == "2"
-	c.private = c.singleplayer || msg[1] == "1"
+	privateHideType, err := strconv.Atoi(msg[1])
+	if err != nil {
+		return err
+	}
+
+	c.privateHideType = privateHideType
+	c.private = privateHideType != 0
 
 	return nil
 }

--- a/server/party.go
+++ b/server/party.go
@@ -133,13 +133,13 @@ func getPartyData(partyId int) (*Party, error) {
 		member.Badge = client.badge
 		member.Medals = client.medals
 
-		if client.roomC != nil && !(client.hideLocation && client.singleplayer) {
+		if client.roomC != nil && !(client.hideLocation && client.isSingleplayer()) {
 			member.MapId = client.roomC.mapId
 			member.PrevMapId = client.roomC.prevMapId
 			member.PrevLocations = client.roomC.prevLocations
 			member.X = client.roomC.x
 			member.Y = client.roomC.y
-		} else if client.roomC != nil && (client.hideLocation && client.singleplayer) {
+		} else if client.roomC != nil && (client.hideLocation && client.isSingleplayer()) {
 			member.MapId = "0000"
 			member.PrevMapId = "0000"
 			member.PrevLocations = ""


### PR DESCRIPTION
This PR replaces the singleplayer variable in SessionClient with a variable called privateHideType which determines who the game hides from the player when they are in private mode.

1 = hide strangers (anyone who isn't a friend or a party member)
2 = hide everybody (singleplayer)
4 = hide friends
8 = hide party members

These can be combined so 4 + 8 = 12 would mean hiding friends and party members. I did not test this PR because I wasn't able to get the server running myself, but it does compile.