### PR TITLE
Don't persist PlayOnce pictures

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -468,7 +468,9 @@ func (c *RoomClient) handleP(msg []string) error {
 	pic.effectMode = effectMode
 	pic.effectPower = effectPower
 
-	c.pictures[id-1] = pic
+	if !pic.spritesheetPlayOnce {
+		c.pictures[id-1] = pic
+	}
 
 	c.broadcast(buildMsg(msg[0], c.session.id, msg[1:]))
 


### PR DESCRIPTION
Attempts to address a CU issue where finished (and cleaned up clientside) eidolon/visage/coin/soulfire animations from other players would play all at once for a newly connected player.

Reproduction steps:
1. make sure you're near the room entrance;
    equip an eidolon/visage or burn something with soulfire;
    don't exit the current room
2. connect another player to the same room