### PR TITLE
Adds server side support for hiding unnamed players

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -92,8 +92,9 @@ type SessionClient struct {
 	// do not compare directly; use isPrivatedTo
 	private, singleplayer bool
 
-	hideLocation bool
-	partyId      int
+	hideLocation       bool
+	hideUnnamedPlayers bool
+	partyId            int
 
 	onlineFriends map[string]bool
 	blockedUsers  map[string]bool
@@ -179,6 +180,14 @@ func (c *SessionClient) isPrivatedTo(other *SessionClient) bool {
 
 func (c *SessionClient) isBlockedWith(other *SessionClient) bool {
 	return c.blockedUsers[other.uuid] || other.blockedUsers[c.uuid]
+}
+
+func (c *SessionClient) isUnnamed() bool {
+	return !c.account && c.name == ""
+}
+
+func (c *SessionClient) isUnnamedPlayerHiddenBy(other *SessionClient) bool {
+	return c.isUnnamed() && other.hideUnnamedPlayers
 }
 
 // RoomClient

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1349,3 +1349,13 @@ func (c *SessionClient) handleHl(msg []string) error {
 
 	return nil
 }
+
+func (c *SessionClient) handleHunp(msg []string) error {
+	if len(msg) != 2 {
+		return errors.New("segment count mismatch")
+	}
+
+	c.hideUnnamedPlayers = msg[1] == "1"
+
+	return nil
+}

--- a/server/room.go
+++ b/server/room.go
@@ -219,6 +219,10 @@ func (c *RoomClient) broadcast(msg []byte) {
 			continue
 		}
 
+		if c.session.isUnnamedPlayerHiddenBy(client.session) {
+			continue
+		}
+
 		select {
 		case client.outbox <- msg:
 		default:
@@ -331,6 +335,10 @@ func (c *RoomClient) getPlayerData(client *RoomClient) {
 	}
 
 	if client.session.isPrivatedTo(c.session) {
+		return
+	}
+
+	if client.session.isUnnamedPlayerHiddenBy(c.session) {
 		return
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -246,6 +246,8 @@ func (c *SessionClient) processMsg(msg []byte) (err error) {
 	case "hl": // hide location
 		err = c.handleHl(msgFields)
 		updateGameActivity = true
+	case "hunp": // hide unnamed players
+		err = c.handleHunp(msgFields)
 	default:
 		err = errors.New("unknown message type")
 	}


### PR DESCRIPTION
### Description
Adds a feature to hide players without name

### Changes
- New `hunp` command to toggle hiding unnamed players
- Unnamed players are filtered from broadcasts and player data

### Motivation
an unnamed player can use a mask to disguise as some NPCs,
disrupting other players online experience
some 2kki devs reported this issue too

Fixes #83
Related: ynoproject/forest-orb#705
