### PR TITLE
change comparison in time trial unlock check

### DIFF
--- a/server/badges.go
+++ b/server/badges.go
@@ -589,7 +589,7 @@ func getPlayerBadgeData(playerUuid string, playerRank int, playerTags []string, 
 					playerBadge.Seconds = gameBadge.ReqInt
 					for _, record := range timeTrialRecords {
 						if record.MapId == gameBadge.Map {
-							playerBadge.Unlocked = record.Seconds < gameBadge.ReqInt
+							playerBadge.Unlocked = record.Seconds <= gameBadge.ReqInt
 						}
 					}
 				case "medal":


### PR DESCRIPTION
from the discord:
https://discord.com/channels/907121695779856394/911980809311907890/1482646081912311939
transcript:
> > > is this supposed to happen?
> > > [image of time trial badge requiring 12:00 or less] [image of completing time trial in exactly 12:00]

> > a mod can grant you the badge, ive had the same for me with another time trial

> it seems in my experience they only work when you have 1 sec less than the requirement, unsure if it's intentional

every time trial badge says "or less" in the english translation, contradicting the current behavior.