### PR TITLE
remove unused 2kki sprite check

### DIFF
--- a/server/assets.go
+++ b/server/assets.go
@@ -183,33 +183,3 @@ func (a *Assets) IsValidPicture(name string) bool {
 	return false
 }
 
-// Yume 2kki
-
-func isValid2kkiSprite(name string, room int) bool {
-	if (allowed2kkiSprites[name] ||
-		(strings.Contains(name, "syujinkou") ||
-			strings.Contains(name, "effect") ||
-			strings.Contains(name, "yukihitsuji_game") ||
-			strings.Contains(name, "zenmaigaharaten_kisekae") ||
-			strings.Contains(name, "主人公"))) &&
-		!(strings.Contains(name, "zenmaigaharaten_kisekae") && room != 176) {
-		return true
-	}
-
-	return true
-}
-
-var allowed2kkiSprites = map[string]bool{
-	"#null":                   true,
-	"kodomo_04-1":             true,
-	"Kong_Urotsuki_CharsetFC": true,
-	"kura CharSet01":          true,
-	"kuro9-8":                 true,
-	"natl_char_uro":           true,
-	"nuls_sujinkou":           true,
-	"RioCharset16":            true,
-	"urotsuki_sniper":         true,
-	"urotsuki_Swimsuit01":     true,
-	"urotsuki_Swimsuit02":     true,
-	"urotsuki_taoru":          true,
-}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -146,10 +146,6 @@ func (c *RoomClient) handleSpr(msg []string) error {
 		return errors.New("invalid sprite")
 	}
 
-	if config.gameName == "2kki" && !isValid2kkiSprite(msg[1], c.room.id) {
-		return errors.New("invalid 2kki sprite")
-	}
-
 	index, errconv := strconv.Atoi(msg[2])
 	if errconv != nil || index < 0 {
 		return errconv


### PR DESCRIPTION
the code removed is dead code due to the condition never being met. both branches of `isValid2kkiSprite` return true which is then negated and an if always fails.

the `isValid2kkiSprite` has unconditionally returned true since january 2023 when commit fc67d371 flipped the condition but not the base case, causing both to converge.

re-enabling the sprite check now would probably cause more problems than it is worth given how outdated the list is.