### PR TITLE
Fix player party assignment logic to set partyId for connected clients

### DIFF
--- a/server/party.go
+++ b/server/party.go
@@ -279,6 +279,11 @@ func joinPlayerParty(partyId int, playerUuid string) error {
 
 		parties[partyId] = &party
 
+		client, ok := clients.Load(playerUuid)
+		if ok {
+			client.partyId = partyId
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
### Description
After creating a party in-game, party features did not work until the player reconnected.


A party was registered in the database, but since the session's `partyId` remained at 0, party chat and related features did not work properly until the player reconnected.

### Changes
Set `client.partyId` on the cache-miss path when the creating player is online.